### PR TITLE
(fix): Added dotenv to handle .env files

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -4,6 +4,10 @@ shards:
     git: https://github.com/sija/backtracer.cr.git
     version: 1.2.4
 
+  dotenv:
+    git: https://github.com/gdotdesign/cr-dotenv.git
+    version: 1.0.0
+
   exception_page:
     git: https://github.com/crystal-loot/exception_page.git
     version: 0.5.0

--- a/shard.yml
+++ b/shard.yml
@@ -13,5 +13,7 @@ crystal: '>= 1.11.2'
 dependencies:
   kemal:
     github: kemalcr/kemal
+  dotenv:
+    github: gdotdesign/cr-dotenv
 
 license: Apache-2.0

--- a/src/analytics-ingestion.cr
+++ b/src/analytics-ingestion.cr
@@ -1,3 +1,6 @@
+require "dotenv"
+Dotenv.load ".env"
+
 require "kemal"
 require "./services/apiKeyValidator.service.cr"
 require "./middleware/auth.cr"


### PR DESCRIPTION
- Previously it was defaulting to the API key from env.src test
- Now it reads from .env